### PR TITLE
Use cdylib instead of dylib

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can configure cargo to build a dynamic library with the following. Note that
 ```toml
 [lib]
 name = "lambda"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 ```
 
 `cargo build` will now build a `liblambda.so`. Put this in a zip file and upload it to an AWS Lambda function. You will need to use the Python 2.7 execution environment with the handler configured as `liblambda.handler`.

--- a/examples/ec2-regions/Cargo.toml
+++ b/examples/ec2-regions/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Iliana Weller <ilianaw@buttslol.net>"]
 
 [lib]
 name = "lambda"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 # Normally you'd write: crowbar = "0.1"

--- a/examples/echo/Cargo.toml
+++ b/examples/echo/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Iliana Weller <ilianaw@buttslol.net>"]
 
 [lib]
 name = "lambda"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 # Normally you'd write: crowbar = "0.2"


### PR DESCRIPTION
Fixes #6 

I've found that we should use `cdylib` for native extensions:
https://github.com/dgrunwald/rust-cpython
https://doc.rust-lang.org/reference/linkage.html
https://github.com/rust-lang/rfcs/blob/master/text/1510-cdylib.md