### PR TITLE
Leave python version selection up to dependent crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,3 @@ exclude = [".gitignore", "builder", "examples"]
 serde_json = "1.0"
 cpython = { version = "0.1", default-features = false }
 cpython-json = { version = "0.2", default-features = false }
-
-[features]
-default = ["python3-sys"]
-python27-sys = ["cpython/python27-sys", "cpython-json/python27-sys"]
-python3-sys = ["cpython/python3-sys", "cpython-json/python3-sys"]

--- a/examples/ec2-regions/Cargo.toml
+++ b/examples/ec2-regions/Cargo.toml
@@ -10,12 +10,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # Normally you'd write: crowbar = "0.2"
-crowbar = { path = "../..", version = "0.2", default-features = false }
+crowbar = { path = "../..", version = "0.2" }
 cpython = { version = "0.1", default-features = false }
 rusoto_core = "0.25"
 rusoto_ec2 = "0.25"
 
 [features]
-default = ["python3-sys"]
-python27-sys = ["crowbar/python27-sys", "cpython/python27-sys"]
-python3-sys = ["crowbar/python3-sys", "cpython/python3-sys"]
+default = ["cpython/python3-sys"]

--- a/examples/echo/Cargo.toml
+++ b/examples/echo/Cargo.toml
@@ -11,4 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # Normally you'd write: crowbar = "0.2"
 crowbar = { path = "../..", version = "0.2" }
-cpython = "0.1"
+cpython = { version = "0.1", default-features = false }
+
+[features]
+default = ["cpython/python3-sys"]


### PR DESCRIPTION
Considering that any dependency of crowbar planning on using the `lambda!()` macro must also depend on cpython we can simplify things here; there's no need for crowbar to have the python version features.

It's also easy to change the python version from the command line when building:

```
cd examples/ec2-regions/
cargo build --no-default-features --features cpython/python27-sys
```