### PR TITLE
Serialize return value bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT/Apache-2.0"
 exclude = [".gitignore", "builder", "examples"]
 
 [dependencies]
+serde = "1.0"
 serde_json = "1.0"
 cpython = { version = "0.1", default-features = false }
 cpython-json = { version = "0.2", default-features = false }

--- a/examples/echo/src/lib.rs
+++ b/examples/echo/src/lib.rs
@@ -3,7 +3,7 @@ extern crate crowbar;
 #[macro_use]
 extern crate cpython;
 
-lambda!(|event, context| {
+lambda!(|event, context| -> crowbar::LambdaResult {
     println!("hello cloudwatch logs from {} version {}, {} ms remaining",
              context.function_name(),
              context.function_version(),

--- a/examples/echo/src/lib.rs
+++ b/examples/echo/src/lib.rs
@@ -3,7 +3,7 @@ extern crate crowbar;
 #[macro_use]
 extern crate cpython;
 
-lambda!(|event, context| -> crowbar::LambdaResult {
+lambda!(|event, context| {
     println!("hello cloudwatch logs from {} version {}, {} ms remaining",
              context.function_name(),
              context.function_version(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,8 @@ pub fn handler<F, O>(py: Python, f: F, py_event: PyObject, py_context: PyObject)
         }).and_then(|v| serde_json::value::to_value(v)
             .map_err(cpython_json::JsonError::SerdeJsonError)
             .map_err(|e| e.to_pyerr(py))
-            .and_then(|v| from_json(py, v).map_err(|e| e.to_pyerr(py)))
+        ).and_then(|v| from_json(py, v)
+            .map_err(|e| e.to_pyerr(py))
         )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub use serde_json::value::Value;
 ///
 /// If an error is thrown, it is converted to a Python `RuntimeError`, and the `Debug` string for
 /// the `Error` returned is used as the value.
-pub type LambdaResult<T> = Result<T, Box<std::error::Error>>;
+pub type LambdaResult<T = Value> = Result<T, Box<std::error::Error>>;
 
 use cpython::{Python, PyUnicode, PyTuple, PyErr, PythonObject, PythonObjectWithTypeObject,
               ObjectProtocol};


### PR DESCRIPTION
Allow handlers to return anything that impls `: serde::Serialize`. This is backward-compatible with the current `serde_json::Value` return type, but also allows for `()` return types or any other serde-compatible type -  the main point here is to be able to return anything that is `#[derive(Serialize)]`.

This is an inefficient implementation, as it uses both `serde_json::value::to_value` and `cpython_json::from_value` to convert. However, this two-step conversion was necessary previously if using serde, so in many cases it's no less efficient than before! Directly converting using a function like `fn to_object<S: Serialize>(py: Python, s: S) -> Result<PyObject, Error>` would be ideal, but that first needs to be written.