### PR TITLE
error-chain support and python Exception

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ serde = "1.0"
 serde_json = "1.0"
 cpython = { version = "0.1", default-features = false }
 cpython-json = { version = "0.2", default-features = false }
+error-chain = { version = "0.11.0", optional = true }
 
 [features]
 default = ["cpython/python3-sys"]
+errorchain = ["error-chain"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ error-chain = { version = "0.11.0", optional = true }
 
 [features]
 default = ["cpython/python3-sys"]
-errorchain = ["error-chain"]
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,18 +89,65 @@ extern crate cpython_json;
 extern crate serde;
 extern crate serde_json;
 
+#[cfg(feature = "errorchain")]
+#[macro_use]
+extern crate error_chain;
+
+#[cfg(feature = "errorchain")]
+mod errors {
+    error_chain!{
+        errors {
+            PyException(message: String) {
+                description("Python Exception")
+                display("Python Exception: {:?}", message)
+            }
+            RustError {
+                description("Rust Exception")
+                display("Rust Exception")
+            }
+        }
+    }
+}
+#[cfg(feature = "errorchain")]
+pub use errors::ErrorKind::{PyException, RustError};
+#[cfg(feature = "errorchain")]
+pub use errors::Error;
+
 #[doc(hidden)]
 pub use cpython::{PyObject, PyResult};
 pub use serde_json::value::Value;
 
 /// Result object that accepts `Ok(T)` or any `Err(Error)`.
 ///
-/// crowbar uses [the `Box<Error>` method of error handling]
+/// crowbar uses [error-chain](https://crates.io/crates/error-chain) under feature errorchain
+///
+/// A PyException can be returned as an error, it is converted to a Python `Exception`, and the
+/// message will be used as the exception's arguments.
+/// If an error is thrown, it is converted to a Python `RuntimeError`, and the `Debug` string for
+/// the `Error` returned is used as the value.
+///
+/// ```rust
+/// #[macro_use(lambda)] extern crate crowbar;
+/// #[macro_use] extern crate cpython;
+/// lambda!(|event, _context| {
+///     match event["authorizationToken"].as_str() {
+///         Some("unauthorized") => Err(crowbar::PyException("Unauthorized".to_string()).into()),
+///         Some(_) => Ok(event),
+///         None => Err("missing token".into()),
+///     }
+/// });
+/// ```
+#[cfg(feature = "errorchain")]
+pub type LambdaResult<T = Value> = errors::Result<T>;
+/// Result object that accepts `Ok(T)` or any `Err(Error)`.
+///
+/// by default, crowbar uses [the `Box<Error>` method of error handling]
 /// (https://doc.rust-lang.org/stable/book/error-handling.html#error-handling-with-boxerror) so
 /// that any `Error` can be thrown within your Lambda function.
 ///
 /// If an error is thrown, it is converted to a Python `RuntimeError`, and the `Debug` string for
 /// the `Error` returned is used as the value.
+#[cfg(not(feature = "errorchain"))]
 pub type LambdaResult<T = Value> = Result<T, Box<std::error::Error>>;
 
 use cpython::{ObjectProtocol, PyErr, PyTuple, PyUnicode, Python, PythonObject,
@@ -251,13 +298,19 @@ where
 {
     let event = to_json(py, &py_event).map_err(|e| e.to_pyerr(py))?;
     f(event, LambdaContext::new(&py, &py_context)?)
-        .map_err(|e| {
-            PyErr {
+        .map_err(|e| { match e {
+            #[cfg(feature = "errorchain")]
+            Error(PyException(message), _) => PyErr {
+                ptype: cpython::exc::Exception::type_object(py).into_object(),
+                pvalue: Some(PyUnicode::new(py, &message).into_object()),
+                ptraceback: None,
+            },
+            _ => PyErr {
                 ptype: cpython::exc::RuntimeError::type_object(py).into_object(),
                 pvalue: Some(PyUnicode::new(py, &format!("{:?}", e)).into_object()),
                 ptraceback: None,
             }
-        })
+        }})
         .and_then(|v| {
             serde_json::value::to_value(v)
                 .map_err(cpython_json::JsonError::SerdeJsonError)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,11 +89,11 @@ extern crate cpython_json;
 extern crate serde;
 extern crate serde_json;
 
-#[cfg(feature = "errorchain")]
+#[cfg(feature = "error-chain")]
 #[macro_use]
 extern crate error_chain;
 
-#[cfg(feature = "errorchain")]
+#[cfg(feature = "error-chain")]
 mod errors {
     error_chain!{
         errors {
@@ -108,9 +108,9 @@ mod errors {
         }
     }
 }
-#[cfg(feature = "errorchain")]
+#[cfg(feature = "error-chain")]
 pub use errors::ErrorKind::{PyException, RustError};
-#[cfg(feature = "errorchain")]
+#[cfg(feature = "error-chain")]
 pub use errors::Error;
 
 #[doc(hidden)]
@@ -119,7 +119,7 @@ pub use serde_json::value::Value;
 
 /// Result object that accepts `Ok(T)` or any `Err(Error)`.
 ///
-/// crowbar uses [error-chain](https://crates.io/crates/error-chain) under feature errorchain
+/// crowbar uses [error-chain](https://crates.io/crates/error-chain) under feature error-chain
 ///
 /// A PyException can be returned as an error, it is converted to a Python `Exception`, and the
 /// message will be used as the exception's arguments.
@@ -137,7 +137,7 @@ pub use serde_json::value::Value;
 ///     }
 /// });
 /// ```
-#[cfg(feature = "errorchain")]
+#[cfg(feature = "error-chain")]
 pub type LambdaResult<T = Value> = errors::Result<T>;
 /// Result object that accepts `Ok(T)` or any `Err(Error)`.
 ///
@@ -147,7 +147,7 @@ pub type LambdaResult<T = Value> = errors::Result<T>;
 ///
 /// If an error is thrown, it is converted to a Python `RuntimeError`, and the `Debug` string for
 /// the `Error` returned is used as the value.
-#[cfg(not(feature = "errorchain"))]
+#[cfg(not(feature = "error-chain"))]
 pub type LambdaResult<T = Value> = Result<T, Box<std::error::Error>>;
 
 use cpython::{ObjectProtocol, PyErr, PyTuple, PyUnicode, Python, PythonObject,
@@ -299,7 +299,7 @@ where
     let event = to_json(py, &py_event).map_err(|e| e.to_pyerr(py))?;
     f(event, LambdaContext::new(&py, &py_context)?)
         .map_err(|e| { match e {
-            #[cfg(feature = "errorchain")]
+            #[cfg(feature = "error-chain")]
             Error(PyException(message), _) => PyErr {
                 ptype: cpython::exc::Exception::type_object(py).into_object(),
                 pvalue: Some(PyUnicode::new(py, &message).into_object()),


### PR DESCRIPTION
added a feature errorchain that switch Error management from a `Box<std::error::Error>` to [error chain](https://crates.io/crates/error-chain)

The motivation behind this change was to be able to throw a basic python Exception use by [API Gateway Custom Authorizer](http://docs.aws.amazon.com/en_en/apigateway/latest/developerguide/use-custom-authorizer.html) to return a 401