### PR TITLE
List alternatives in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 crowbar makes it easy to write AWS Lambda functions in Rust. It wraps native Rust functions into CPython modules that
 handle converting Python objects into Rust objects and back again.
 
+## Alternatives
+
+As AWS Lambda has added more runtimes, more ways to run Rust on Lambda have emerged.
+
+The [Rust on AWS Lambda](https://srijs.github.io/rust-aws-lambda/) project is kind enough to offer an alternative, and a comparison of itself to crowbar.
+
 ## Usage
 
 Add both crowbar and cpython to your `Cargo.toml`:


### PR DESCRIPTION
crowbar is really cool, but there are some other really cool projects that solve similar problems. Arguably, rust-aws-lambda, despite its worse name, solves the problem better by merit of coming into existence after lambda added go support.

At the very least it seems like a good idea to let users know of the alternatives.

If you'd rather me word it differently or create a crowbar-biased comparison, I'd be happy to.