### PR TITLE
format errors for human consumption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0"
 cpython = { version = "0.1", default-features = false }
 cpython-json = { version = "0.2", default-features = false }
 error-chain = { version = "0.11.0", optional = true }
+log = "0.4"
 
 [features]
 default = ["cpython/python3-sys"]
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ mod errors {
         errors {
             PyException(message: String) {
                 description("Python Exception")
-                display("Python Exception: {:?}", message)
+                display("Python Exception: {}", message)
             }
             RustError {
                 description("Rust Exception")
@@ -123,7 +123,7 @@ pub use serde_json::value::Value;
 ///
 /// A PyException can be returned as an error, it is converted to a Python `Exception`, and the
 /// message will be used as the exception's arguments.
-/// If an error is thrown, it is converted to a Python `RuntimeError`, and the `Debug` string for
+/// If an Error type is returned, it is converted to a Python `RuntimeError`, and the `Display` string for
 /// the `Error` returned is used as the value.
 ///
 /// ```rust
@@ -145,7 +145,7 @@ pub type LambdaResult<T = Value> = errors::Result<T>;
 /// (https://doc.rust-lang.org/stable/book/error-handling.html#error-handling-with-boxerror) so
 /// that any `Error` can be thrown within your Lambda function.
 ///
-/// If an error is thrown, it is converted to a Python `RuntimeError`, and the `Debug` string for
+/// If an Error type is returned, it is converted to a Python `RuntimeError`, and the `Display` string for
 /// the `Error` returned is used as the value.
 #[cfg(not(feature = "error-chain"))]
 pub type LambdaResult<T = Value> = Result<T, Box<std::error::Error>>;
@@ -307,7 +307,7 @@ where
             },
             _ => PyErr {
                 ptype: cpython::exc::RuntimeError::type_object(py).into_object(),
-                pvalue: Some(PyUnicode::new(py, &format!("{:?}", e)).into_object()),
+                pvalue: Some(PyUnicode::new(py, &format!("{}", e)).into_object()),
                 ptraceback: None,
             }
         }})


### PR DESCRIPTION
this addresses #42 I've found that print a Debug implementation of errors lends itself toward communication less useful information that Display which lends itself more towards communicating errors for humans