### PR TITLE
 Upgrade to cpython 0.2 and cpython-json 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crowbar"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Iliana Weller <ilianaw@buttslol.net>"]
 description = "Wrapper to simplify writing AWS Lambda functions in Rust (using the Python execution environment)"
 readme = "README.md"
@@ -13,8 +13,8 @@ exclude = [".gitignore", "builder/**", "examples/**", "test/**"]
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-cpython = { version = "0.1", default-features = false }
-cpython-json = { version = "0.2", default-features = false }
+cpython = { version = "0.2", default-features = false }
+cpython-json = { version = "0.3", default-features = false }
 error-chain = { version = "0.11.0", optional = true }
 log = "0.4"
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Add both crowbar and cpython to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-crowbar = "0.2"
-cpython = "0.1"
+crowbar = "0.3"
+cpython = "0.2"
 ```
 
 Use macros from both crates:

--- a/examples/ci/circle/Cargo.toml
+++ b/examples/ci/circle/Cargo.toml
@@ -12,8 +12,8 @@ name = "lambda"
 crate-type = ["cdylib"]
 
 [dependencies]
-crowbar = { version = "0.2", default-features = false }
-cpython = { version = "0.1", default-features = false }
+crowbar = { version = "0.3", default-features = false }
+cpython = { version = "0.2", default-features = false }
 
 [features]
 default = ["cpython/python3-sys"]

--- a/examples/ci/travis/Cargo.toml
+++ b/examples/ci/travis/Cargo.toml
@@ -12,8 +12,8 @@ name = "lambda"
 crate-type = ["cdylib"]
 
 [dependencies]
-crowbar = { version = "0.2", default-features = false }
-cpython = { version = "0.1", default-features = false }
+crowbar = { version = "0.3", default-features = false }
+cpython = { version = "0.2", default-features = false }
 
 [features]
 default = ["cpython/python3-sys"]

--- a/examples/ec2-regions/Cargo.toml
+++ b/examples/ec2-regions/Cargo.toml
@@ -4,8 +4,8 @@
 #
 # - Change the name, version, and authors under [package]
 # - Use this as your [dependencies] section:
-#   crowbar = "0.2"
-#   cpython = "0.1"
+#   crowbar = "0.3"
+#   cpython = "0.2"
 # - Remove the [features] section
 #
 # If you need to use Python 2.7 refer to the crate-level documentation.
@@ -21,8 +21,8 @@ name = "lambda"
 crate-type = ["cdylib"]
 
 [dependencies]
-crowbar = { path = "../..", version = "0.2", default-features = false }
-cpython = { version = "0.1", default-features = false }
+crowbar = { path = "../..", version = "0.3", default-features = false }
+cpython = { version = "0.2", default-features = false }
 rusoto_core = "0.28"
 rusoto_ec2 = "0.28"
 

--- a/examples/echo/Cargo.toml
+++ b/examples/echo/Cargo.toml
@@ -4,8 +4,8 @@
 #
 # - Change the name, version, and authors under [package]
 # - Use this as your [dependencies] section:
-#   crowbar = "0.2"
-#   cpython = "0.1"
+#   crowbar = "0.3"
+#   cpython = "0.2"
 # - Remove the [features] section
 #
 # If you need to use Python 2.7 refer to the crate-level documentation.
@@ -21,8 +21,8 @@ name = "lambda"
 crate-type = ["cdylib"]
 
 [dependencies]
-crowbar = { path = "../..", version = "0.2", default-features = false }
-cpython = { version = "0.1", default-features = false }
+crowbar = { path = "../..", version = "0.3", default-features = false }
+cpython = { version = "0.2", default-features = false }
 
 [features]
 default = ["cpython/python3-sys"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! crowbar = "0.2"
-//! cpython = "0.1"
+//! crowbar = "0.3"
+//! cpython = "0.2"
 //! ```
 //!
 //! Use macros from both crates:
@@ -80,8 +80,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! crowbar = { version = "0.2", default-features = false }
-//! cpython = { version = "0.1", default-features = false, features = ["python27-sys"] }
+//! crowbar = { version = "0.3", default-features = false }
+//! cpython = { version = "0.2", default-features = false, features = ["python27-sys"] }
 //! ```
 
 extern crate cpython;


### PR DESCRIPTION
This updates the versions of the cpython dependency to 0.2 and cpython-json to 0.3. The release version is updated to 0.3 to reflect this change.

Note that this depends on https://github.com/ilianaw/rust-cpython-json/pull/2 to work. Refer to that pull request for more information on the motivation for this change.