### PR TITLE
initial sketch of a test friendly lambda context interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,7 +294,31 @@ impl<'a> LambdaContext<'a> {
     }
 
     #[cfg(test)]
-    pub fn with_get_remaining_time_in_millis(mut self, time: u64) -> Self {
+    pub fn with_memory_limit_in_mb<S>(mut self, value: S) -> Self where S: Into<String> {
+        self.string_storage[3] = value.into();
+        self
+    }
+
+    #[cfg(test)]
+    pub fn with_aws_request_id<S>(mut self, value: S) -> Self where S: Into<String> {
+        self.string_storage[4] = value.into();
+        self
+    }
+
+    #[cfg(test)]
+    pub fn with_log_group_name<S>(mut self, value: S) -> Self where S: Into<String> {
+        self.string_storage[5] = value.into();
+        self
+    }
+
+    #[cfg(test)]
+    pub fn with_log_stream_name<S>(mut self, value: S) -> Self where S: Into<String> {
+        self.string_storage[6] = value.into();
+        self
+    }
+
+    #[cfg(test)]
+    pub fn with_remaining_time_in_millis(mut self, time: u64) -> Self {
         self.remaining_time = Box::new(move || {
             Ok(time)
         });
@@ -513,10 +537,18 @@ mod tests {
             .with_function_name("test")
             .with_function_version("1.0")
             .with_invoked_function_arn("testarn")
-            .with_get_remaining_time_in_millis(5_000);
+            .with_memory_limit_in_mb("128")
+            .with_aws_request_id("123")
+            .with_log_group_name("foobar")
+            .with_log_stream_name("bazboom")
+            .with_remaining_time_in_millis(5_000);
         assert_eq!(fake.function_name(), "test");
         assert_eq!(fake.function_version(), "1.0");
         assert_eq!(fake.invoked_function_arn(), "testarn");
+        assert_eq!(fake.memory_limit_in_mb(), "128");
+        assert_eq!(fake.aws_request_id(), "123");
+        assert_eq!(fake.log_group_name(), "foobar");
+        assert_eq!(fake.log_stream_name(), "bazboom");
         assert_eq!(fake.get_remaining_time_in_millis(), Ok(5_000));
     }
 }


### PR DESCRIPTION
fixes: #51

@ilianaw I took an initial stab at this. let me know what you think. Context here is I'd like to improve the story around unit testing. Atm this is not possible because the `new` constructor is private to callers and even it were public it would be awkward to construct with a bring-your-own-py api. 

I tried two approaches and settled on the second. I first tried extracting out LambdaContext into a trait but this required a change to the handler api so I punted on that. The second try was to make the existing LambdaContext type's a little more generalized. Rather than storing and operating on py objects it just operates on raw data. I created a new factory method named `fake` ( open to other suggestions ) that creates a fake `LambdaContext` which is only available in test contexts. This avoids any any bloat to production binaries. I also sketched out a few methods that serve as "builder" style api  also only available in the test context. This leaves the production binary interface immutable, as it should be :)

Let me know what you think and if this looks good. I'll fill out the remaining builder methods.