### PR TITLE
introducing #[lambdafn]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT/Apache-2.0"
 exclude = [".gitignore", "builder/**", "examples/**", "test/**"]
 
 [dependencies]
+crowbar-attr = { version = "0.3.0", path = "crowbar-attr" }
 serde = "1.0"
 serde_json = "1.0"
 cpython = { version = "0.2", default-features = false }

--- a/crowbar-attr/Cargo.toml
+++ b/crowbar-attr/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "crowbar-attr"
+version = "0.3.0"
+authors = ["Iliana Weller <ilianaw@buttslol.net>"]
+description = "Provides rust-crowbar proc macro attribute"
+readme = "../README.md"
+repository = "https://github.com/ilianaw/rust-crowbar"
+documentation = "https://docs.rs/crowbar"
+keywords = ["aws", "lambda"]
+license = "MIT/Apache-2.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "0.6"
+
+[dependencies.syn]
+version = "0.15"
+features = ["full"]

--- a/crowbar-attr/Cargo.toml
+++ b/crowbar-attr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crowbar-attr"
 version = "0.3.0"
-authors = ["Iliana Weller <ilianaw@buttslol.net>"]
+authors = ["Iliana Weller <ilianaw@buttslol.net>", "Doug Tangren <d.tangren@gmail.com>"]
 description = "Provides rust-crowbar proc macro attribute"
 readme = "../README.md"
 repository = "https://github.com/ilianaw/rust-crowbar"

--- a/crowbar-attr/src/lib.rs
+++ b/crowbar-attr/src/lib.rs
@@ -60,7 +60,7 @@ fn attr_impl(_: TokenStream, input: TokenStream) -> TokenStream {
         ReturnType::Default => {
             // https://doc.rust-lang.org/proc_macro/struct.Span.html#method.error
             // use span diagnotics when it becomes stable
-            panic!("the 'lambdafn' attribute requires a function that returns a. expecting {}(_: crowbar::Value, _: crowbar::LambdaContext) -> crowbar::LambdaResult", target.ident);
+            panic!("the 'lambdafn' attribute requires a function that returns a value. expecting {}(_: crowbar::Value, _: crowbar::LambdaContext) -> crowbar::LambdaResult", target.ident);
         },
         _ => ()
     }

--- a/crowbar-attr/src/lib.rs
+++ b/crowbar-attr/src/lib.rs
@@ -1,0 +1,75 @@
+//! provides function attribute macros for rust-crowbar crate
+
+extern crate proc_macro;
+#[macro_use]
+extern crate quote;
+extern crate syn;
+
+// std lib(ish)
+use proc_macro::TokenStream;
+
+// third party
+use syn::{parse, ItemFn, ReturnType};
+
+/// Implements the `lambdafn` attribute.
+///
+/// This attribute is used to export a Rust function into an
+/// AWS triggerable Lambda function. In lambda you can refer to these by path with
+/// `liblambda.{fn_name}`
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// #[macro_use] extern crate crowbar;
+/// #[macro_use] extern crate cpython;
+///
+/// #[lambdafn]
+/// fn example(
+///     event: crowbar::Value,
+///     ctx: crowbar::LambdaContext
+/// ) -> crowbar::LambdaResult {
+///     Ok(event)
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn lambdafn(args: TokenStream, input: TokenStream) -> TokenStream {
+    attr_impl(args, input)
+}
+
+// implementation. should expect the following
+// * verify function type
+// * input args are (event, context)
+// * has a return type
+fn attr_impl(_: TokenStream, input: TokenStream) -> TokenStream {
+    let target: ItemFn = match parse(input.clone()) {
+        Ok(f) => f,
+        _ => {
+            panic!("the 'lambdafn' attribute can only be used on functions");
+            // https://doc.rust-lang.org/proc_macro/struct.Span.html#method.error
+            // use span diagnotics when this becomes stable
+        }
+    };
+    if target.decl.inputs.len() != 2 {
+        panic!(
+            "the 'lambdafn' attribute requires a function with two arguments. expecting {}(_: lando::Request, _: lando::LambdaContext) -> lando::Result", target.ident
+            );
+            // https://doc.rust-lang.org/proc_macro/struct.Span.html#method.error
+            // use span diagnotics when it becomes stable
+    }
+    match target.decl.output {
+        ReturnType::Default => {
+            // https://doc.rust-lang.org/proc_macro/struct.Span.html#method.error
+            // use span diagnotics when it becomes stable
+            panic!("the 'lambdafn' attribute requires a function that returns a. expecting {}(_: lando::Request, _: lando::LambdaContext) -> lando::Result", target.ident);
+        },
+        _ => ()
+    }
+    let target_ident = target.ident.clone();
+    let target_name = target_ident.to_string();
+    let expanded = quote! {
+        #target
+
+        lambda!(stringify!(#target_name) => #target_ident);
+    };
+    expanded.into()
+}

--- a/crowbar-attr/src/lib.rs
+++ b/crowbar-attr/src/lib.rs
@@ -5,10 +5,7 @@ extern crate proc_macro;
 extern crate quote;
 extern crate syn;
 
-// std lib(ish)
 use proc_macro::TokenStream;
-
-// third party
 use syn::{parse, ItemFn, ReturnType};
 
 /// Implements the `lambdafn` attribute.

--- a/crowbar-attr/src/lib.rs
+++ b/crowbar-attr/src/lib.rs
@@ -66,7 +66,7 @@ fn attr_impl(_: TokenStream, input: TokenStream) -> TokenStream {
     let expanded = quote! {
         #target
 
-        lambda!(stringify!(#target_name) => #target_ident);
+        lambda!(#target_name => #target_ident);
     };
     expanded.into()
 }

--- a/crowbar-attr/src/lib.rs
+++ b/crowbar-attr/src/lib.rs
@@ -51,7 +51,7 @@ fn attr_impl(_: TokenStream, input: TokenStream) -> TokenStream {
     };
     if target.decl.inputs.len() != 2 {
         panic!(
-            "the 'lambdafn' attribute requires a function with two arguments. expecting {}(_: lando::Request, _: lando::LambdaContext) -> lando::Result", target.ident
+            "the 'lambdafn' attribute requires a function with two arguments. expecting {}(_: crowbar::Value, _: crowbar::LambdaContext) -> crowbar::LambdaResult", target.ident
             );
             // https://doc.rust-lang.org/proc_macro/struct.Span.html#method.error
             // use span diagnotics when it becomes stable
@@ -60,7 +60,7 @@ fn attr_impl(_: TokenStream, input: TokenStream) -> TokenStream {
         ReturnType::Default => {
             // https://doc.rust-lang.org/proc_macro/struct.Span.html#method.error
             // use span diagnotics when it becomes stable
-            panic!("the 'lambdafn' attribute requires a function that returns a. expecting {}(_: lando::Request, _: lando::LambdaContext) -> lando::Result", target.ident);
+            panic!("the 'lambdafn' attribute requires a function that returns a. expecting {}(_: crowbar::Value, _: crowbar::LambdaContext) -> crowbar::LambdaResult", target.ident);
         },
         _ => ()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,12 @@
 //!
 //! Use macros from both crates:
 //!
-//! ```rust,ignore
-//! #[macro_use(lambda)]
+//! ```rust
+//! #[macro_use]
 //! extern crate crowbar;
 //! #[macro_use]
 //! extern crate cpython;
+//! # fn main() { }
 //! ```
 //!
 //! And write your function using the `lambda!` macro:
@@ -32,6 +33,20 @@
 //!     Ok(event)
 //! });
 //! # }
+//! ```
+//!
+//! Alternatively, you can also just attribute a bare handler `fn` with `#[lambdafn]`
+//!
+//! ```rust
+//! # #[macro_use] extern crate crowbar;
+//! # #[macro_use] extern crate cpython;
+//! #[lambdafn]
+//! fn handler(
+//!     event: crowbar::Value,
+//!     ctx: crowbar::LambdaContext
+//! ) -> crowbar::LambdaResult {
+//!     Ok(event)
+//! }
 //! ```
 //!
 //! # Building Lambda functions
@@ -84,6 +99,8 @@
 //! cpython = { version = "0.2", default-features = false, features = ["python27-sys"] }
 //! ```
 
+extern crate crowbar_attr;
+pub use crowbar_attr::*;
 extern crate cpython;
 extern crate cpython_json;
 #[macro_use]


### PR DESCRIPTION
now that proc-macro [works on stable](https://blog.rust-lang.org/2018/10/25/Rust-1.30.0.html) I wanted to introduce a new way to export lambda functions with crowbar, attributing bare functions. This is something I'm also experimenting with the [lando](https://github.com/softprops/lando) crate. Included in this pull is a doc example but in a nut shell the idea is simple. Any function with the attribute `#[lambdafn]` will get its declaration parsed expecting two args ( assuming event and context ) and a return value. its function name will get used to synthesize. 

```rust
lambda!("functionname" => functionhandle);
```

I think this is going to be a direction more crates are taking so I wanted to give this an early try in crowbar.

Initial thoughts I had were me wanting to reuse lambda for the proc-macro name `#[lambda]` but that conflicts with the declarative form. `lambdafn` was kind of comprise but I'm open to suggestions.

Let me know what you think @ilianaw.
